### PR TITLE
Feature/th 501 delete user

### DIFF
--- a/src/main/java/net/app/savable/controller/MemberController.java
+++ b/src/main/java/net/app/savable/controller/MemberController.java
@@ -1,5 +1,7 @@
 package net.app.savable.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.app.savable.domain.member.Member;
@@ -12,9 +14,7 @@ import net.app.savable.global.error.ApiResponse;
 import net.app.savable.service.MemberService;
 import net.app.savable.service.ParticipationChallengeService;
 import net.app.savable.service.VerificationService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -50,5 +50,18 @@ public class MemberController {
                 .build();
 
         return ApiResponse.success(myPageResponseDto);
+    }
+
+    @PatchMapping("/member/{memberId}")
+    public ApiResponse<String> memberRemove(@LoginMember SessionMember sessionMember, HttpServletRequest request) {
+        log.info("MemberController.deleteMember() 실행");
+        memberService.deleteMember(sessionMember.getId());
+
+        HttpSession session = request.getSession();
+        if (session != null) {
+            session.invalidate(); // 세션 무효화
+        }
+
+        return ApiResponse.success("회원 탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/net/app/savable/domain/challenge/dto/VerificationRequestDto.java
+++ b/src/main/java/net/app/savable/domain/challenge/dto/VerificationRequestDto.java
@@ -7,8 +7,6 @@ import net.app.savable.domain.challenge.Verification;
 import net.app.savable.domain.challenge.VerificationState;
 import net.app.savable.domain.member.Member;
 
-import java.sql.Timestamp;
-
 @Getter
 public class VerificationRequestDto {
     private String image;

--- a/src/main/java/net/app/savable/domain/challenge/dto/VerificationResponseDto.java
+++ b/src/main/java/net/app/savable/domain/challenge/dto/VerificationResponseDto.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.app.savable.domain.challenge.VerificationState;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/net/app/savable/domain/member/BaseTimeEntity.java
+++ b/src/main/java/net/app/savable/domain/member/BaseTimeEntity.java
@@ -7,7 +7,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/net/app/savable/domain/member/Member.java
+++ b/src/main/java/net/app/savable/domain/member/Member.java
@@ -10,6 +10,7 @@ import net.app.savable.domain.history.SavingsHistory;
 import net.app.savable.domain.shop.GiftcardOrder;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -46,6 +47,8 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     @ColumnDefault("'ACTIVE'")
     private AccountState accountState;
+
+    private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL) // Member 1 : N ParticipationChallenge
     private List<ParticipationChallenge> participationChallengeList;

--- a/src/main/java/net/app/savable/domain/member/Member.java
+++ b/src/main/java/net/app/savable/domain/member/Member.java
@@ -89,6 +89,14 @@ public class Member extends BaseTimeEntity {
         return this;
     }
 
+    public Member delete(){
+        this.email = null;
+        this.accountState = AccountState.DELETED;
+        this.deletedAt = LocalDateTime.now();
+
+        return this;
+    }
+
     public String getRoleKey(){
         return this.role.getKey();
     }

--- a/src/main/java/net/app/savable/service/MemberService.java
+++ b/src/main/java/net/app/savable/service/MemberService.java
@@ -5,15 +5,25 @@ import lombok.extern.slf4j.Slf4j;
 import net.app.savable.domain.member.Member;
 import net.app.savable.domain.member.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
     private final MemberRepository memberRepository;
 
     public Member findById(Long memberId){
         return memberRepository.findById(memberId)
                 .orElseThrow(()-> new IllegalArgumentException("INVALID_MEMBER"+memberId));
+    }
+
+    @Transactional(readOnly = false)
+    public Member deleteMember(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new IllegalArgumentException("INVALID_MEMBER"+memberId));
+
+        return member.delete();
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타

## 📌 개발 사항
- 회원 탈퇴 API 개발

## 📌 참고 사항
- 탈퇴 시간 추정을 위해, Member 테이블의 Column으로 deleted_at을 추가했습니다.
- 탈퇴 시, email을 null로 만들어 추후 동일 아이디로 로그인 할 경우 unique email에 대한 문제가 발생하지 않도록 했습니다.
- 탈퇴를 하더라도 기존 유저의 닉네임은 삭제되지 않도록 할 것입니다. 즉, 해당 유저 닉네임은 탈퇴하더라도 다른 유저가 사용할 수 없습니다.
- 탈퇴 후 session이 바로 무효화됩니다.
