### PR TITLE
S3에 저장되는 이미지 URL을 유추하지 못하도록 변경

### DIFF
--- a/src/main/java/net/app/savable/controller/MemberController.java
+++ b/src/main/java/net/app/savable/controller/MemberController.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -114,7 +115,7 @@ public class MemberController {
         String saveFileName; // S3에 저장된 파일 이름
         try { // S3에 프로필 이미지 업로드
             log.info("S3에 이미지 업로드");
-            String fileName = generateFileName(sessionMember.getId(), Timestamp.valueOf(LocalDateTime.now()));
+            String fileName = generateFileName(sessionMember.getId());
             saveFileName = s3UploadService.saveFile(file, fileName);
         } catch (Exception e) {
             return ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR, "S3에 이미지 업로드를 실패했습니다.");
@@ -164,7 +165,7 @@ public class MemberController {
             log.info("S3에 이미지 업로드");
 
             URL url = new URL(imageUrl);
-            String fileName = generateFileName(sessionMember.getId(), Timestamp.valueOf(LocalDateTime.now()));
+            String fileName = generateFileName(sessionMember.getId());
 
             Path tempFile = Files.createTempFile("temp", ".jpg");
             Files.copy(url.openStream(), tempFile, StandardCopyOption.REPLACE_EXISTING);
@@ -184,9 +185,11 @@ public class MemberController {
         return ApiResponse.success("회원 정보 수정이 완료되었습니다.");
     }
 
-    private static String generateFileName(Long memberId, Timestamp timestamp) {
+    public static String generateFileName(Long memberId) {
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+
         return String.format("profile/member_%d_%s.jpg",
-                memberId, timestamp.toString());
+                memberId, uuid);
     }
 
     private boolean isValid(String input, String pattern) {

--- a/src/main/java/net/app/savable/controller/VerificationController.java
+++ b/src/main/java/net/app/savable/controller/VerificationController.java
@@ -20,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -40,7 +41,7 @@ public class VerificationController {
         String saveFileName; // S3에 저장된 파일 이름
         try {
             log.info("S3에 이미지 업로드");
-            String fileName = generateFileName(member.getId(), participationId, Timestamp.valueOf(LocalDateTime.now()));
+            String fileName = generateFileName(member.getId(), participationId);
             saveFileName = s3UploadService.saveFile(file, fileName);
         } catch (Exception e) {
             return ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR, "S3에 이미지 업로드를 실패했습니다.");
@@ -58,9 +59,10 @@ public class VerificationController {
         return ApiResponse.success("인증이 완료되었습니다.");
     }
 
-    private static String generateFileName(Long memberId, Long participationId, Timestamp timestamp) {
+    public static String generateFileName(Long memberId, Long participationId) {
+        String uuid = UUID.randomUUID().toString().replace("-", "");
         return String.format("verification/member_%d/participation_%d_%s.jpg",
-                memberId, participationId, timestamp.toString());
+                memberId, participationId, uuid);
     }
 
     @GetMapping("/{participationId}/verification")


### PR DESCRIPTION
## 📌 PR 타입
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타

## 📌 개발 사항
S3에 저장되는 이미지 URL을 유추하지 못하도록 변경

## 📌 참고 사항
- 기존에 S3에 저장되는 이미지 이름의 경우 유추가 가능하다는 점에서 보안상의 문제가 있다고 판단하여, 유추가 불가능 하도록 이미지 이름을 변경했습니다.
